### PR TITLE
Adding .probo.yaml.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,0 +1,28 @@
+assets:
+  - wordpress_github.sql.gz
+steps:
+  - name: Check wp-cli.
+    plugin: Script
+    script:
+      - wp --info --allow-root
+  - name: Update wp-cli.
+    plugin: Script
+    script:
+      - wp cli update --allow-root --yes
+  - name: Check wp-cli version again.
+    plugin: Script
+    script:
+      - wp --info --allow-root
+  - name: Site setup
+    plugin: WordPressApp
+    database: 'wordpress_github.sql.gz'
+    databaseName: 'wordpress'
+    databaseGzipped: true
+    subDirectory: 'code'
+    devDomain: 'http://example.com'
+    devHome: 'http://example.com/'
+    flushCaches: true
+  - name: Create admin user.
+    plugin: Script
+    script:
+      - wp user create admin dev@probo.ci --role=administrator --allow-root


### PR DESCRIPTION
In this example, we have 5 Probo steps.

**Step 1:** Checks the current version of [wp-cli](http://wp-cli.org/).
**Step 2:** Updates `wp-cli` to the latest version.
**Step 3:** Checks `wp-cli` version again to verify it was updated.
Step 4: **Install Wordpress.**
**Step 5:** Create a user with `wp-cli`, admin, with a random password for logging into the site in the Probo Build.